### PR TITLE
FIX ReferenceError: helpers is not defined. 

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,11 +39,6 @@ exports.whenDirectoryExists = function(directory, callback) {
   })
 }
 
-exports.trim = function(text) {
-
-  return text.replace(/^\s*/, '').replace(/\s*$/, '')
-}
-
 exports.traverseDir = function(dir, callback) {
 
   fs.readdir(dir, function(err, children) {
@@ -368,7 +363,7 @@ exports.readIgnoreListFromFile = function(file) {
     }
 
     // trim blank space from start/end of line
-    line = helpers.trim(line)
+    line = line.trim();
 
     // change file pattern to regex
     line = '^' + line.replace(/\*/g, '(.*)') + '$'


### PR DESCRIPTION
I recently added a README.md to my dotfiles. Now I found out i could ignore files with deja by adding a `.dejaignore_local`  file to my dotfiles repository. So I did ran `echo README.md > .dejaignore_local`.

After this I run `deja link dotfiles` and get this error message

```
/usr/local/lib/node_modules/deja/lib/helpers.js:371
    line = helpers.trim(line)
           ^
ReferenceError: helpers is not defined
    at Object.readIgnoreListFromFile (/usr/local/lib/node_modules/deja/lib/helpers.js:371:12)
    at /usr/local/lib/node_modules/deja/lib/helpers.js:335:34
    at Object.oncomplete (path.js:415:19)
```

OSX 10.7.4
node 0.6.19 / 0.8
deja  0.1.7
npm 1.1.18 / 1.1.32

I don't know exactly when node.js/v8 started supporting ECMAScript 5 #trim(), but node 0.8 does, so I replaced the "old" RegEx version (which wasn't found ) and replaced it with the native call.

PS
Why is the file called `.dejaignore_local` and not just `.dejaignore` which seems to be inline with git and npm?
